### PR TITLE
Integrate with travis and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - '0.10'
 install: npm install
 script: npm run coverage
+after_script: npm run coveralls
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '0.11'
   - '0.10'
 install: npm install
-script: npm test
+script: npm run coverage
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '0.11'
+  - '0.10'
+install: npm install
+script: npm test
+branches:
+  only:
+    - master
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/package.json
+++ b/package.json
@@ -2,13 +2,18 @@
   "name": "datapackage-registry",
   "version": "0.1.0",
   "description": "An API wrapper for a Data Package registry.",
-  "keywords": ["data package", "frictionless data", "open data", "open knowledge"],
+  "keywords": [
+    "data package",
+    "frictionless data",
+    "open data",
+    "open knowledge"
+  ],
   "main": "index.js",
   "dependencies": {
     "csv": "^0.4.1",
-    "promise-polyfill": "^2.0.2",
     "superagent": "^1.2.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "bluebird": "~2.9.34"
   },
   "devDependencies": {
     "chai": "^3.0.0",
@@ -42,9 +47,9 @@
   ],
   "homepage": "https://github.com/okfn/datapackage-registry-js",
   "bugs": "https://github.com/okfn/datapackage-registry-js/issues",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/okfn/datapackage-registry-js.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/okfn/datapackage-registry-js.git"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "mocha": "^2.2.5",
-    "superagent-mock": "^1.2.0"
+    "superagent-mock": "^1.2.0",
+    "istanbul": "~0.3.19"
   },
   "scripts": {
-    "test": "mocha ./"
+    "test": "mocha ./",
+    "coverage": "istanbul cover _mocha -- -R spec ."
   },
   "author": {
     "name": "Open Knowledge",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "chai": "^3.0.0",
     "mocha": "^2.2.5",
     "superagent-mock": "^1.2.0",
-    "istanbul": "~0.3.19"
+    "istanbul": "~0.3.19",
+    "coveralls": "~2.11.4"
   },
   "scripts": {
     "test": "mocha ./",
-    "coverage": "istanbul cover _mocha -- -R spec ."
+    "coverage": "istanbul cover _mocha -- -R spec .",
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "author": {
     "name": "Open Knowledge",


### PR DESCRIPTION
Hi, I saw that you have added travis and coveralls badges, but without the proper configuration. So I'm sending this PR adding .travis.yml with coveralls integration.
- fix dependencies
- add .travis.yml configuration file
- add coverage reporter (npm run coverage)
- integrate with coveralls 

[]'s
